### PR TITLE
Fix anchor unchecked and clippy errors

### DIFF
--- a/programs/libreplex_legacy/src/instructions/check_metadata_type.rs
+++ b/programs/libreplex_legacy/src/instructions/check_metadata_type.rs
@@ -31,8 +31,8 @@ pub fn check_metadata_type(
     mint: &Account<Mint>,
 ) -> Result<()> {
     let mai = legacy_metadata.to_account_info().clone();
-    let data: &[u8] = &mai.try_borrow_data()?[..];
-    let metadata_obj = Metadata::deserialize(&mut data.clone())?;
+    let mut data: &[u8] = &mai.try_borrow_data()?[..];
+    let metadata_obj = Metadata::deserialize(&mut data)?;
     if metadata_obj.mint != mint.key() {
         return Err(LegacyInscriptionErrorCode::BadMint.into());
     }

--- a/programs/libreplex_legacy/src/instructions/inscribe_legacy_metadata_as_holder.rs
+++ b/programs/libreplex_legacy/src/instructions/inscribe_legacy_metadata_as_holder.rs
@@ -46,6 +46,7 @@ pub struct InscribeLegacyMetadataAsHolder<'info> {
     #[account(mut)]
     pub inscription: UncheckedAccount<'info>,
 
+    /// CHECK: Checked via a CPI call
     #[account(mut)]
     pub inscription_v2: UncheckedAccount<'info>,
 

--- a/programs/libreplex_legacy/src/instructions/inscribe_legacy_metadata_as_uauth.rs
+++ b/programs/libreplex_legacy/src/instructions/inscribe_legacy_metadata_as_uauth.rs
@@ -42,6 +42,7 @@ pub struct InscribeLegacyMetadataAsUauth<'info> {
     #[account(mut)]
     pub inscription: UncheckedAccount<'info>,
 
+    /// CHECK: Checked via a CPI call
     #[account(mut)]
     pub inscription_v2: UncheckedAccount<'info>,
 

--- a/programs/libreplex_legacy/src/instructions/make_immutable.rs
+++ b/programs/libreplex_legacy/src/instructions/make_immutable.rs
@@ -20,6 +20,7 @@ pub struct MakeImmutable<'info> {
     #[account(mut)]
     pub inscription: UncheckedAccount<'info>,
 
+    /// CHECK: Checked via a CPI call
     #[account(mut)]
     pub inscription_v2: UncheckedAccount<'info>,
 
@@ -78,7 +79,7 @@ pub fn handler(ctx: Context<MakeImmutable>) -> Result<()> {
     )?;
     check_metadata_type(legacy_metadata, mint)?;
 
-
+    
     let inscription_v2_seeds: &[&[u8]] = &[
         "inscription_v3".as_bytes(),
         mint_key.as_ref()

--- a/programs/libreplex_legacy/src/instructions/resize_legacy_inscription_as_uauth.rs
+++ b/programs/libreplex_legacy/src/instructions/resize_legacy_inscription_as_uauth.rs
@@ -48,6 +48,7 @@ pub struct ResizeLegacyInscriptionAsUauth<'info> {
     #[account(mut)]
     pub inscription: Account<'info, Inscription>,
 
+    /// CHECK: Checked via a CPI call
     #[account(mut)]
     pub inscription_v2: UncheckedAccount<'info>,
 
@@ -146,8 +147,8 @@ pub fn check_metadata_uauth(
     authority_type: AuthorityType,
 ) -> Result<Metadata> {
     let mai = metaplex_metadata.to_account_info().clone();
-    let data: &[u8] = &mai.try_borrow_data()?[..];
-    let metadata_obj = Metadata::deserialize(&mut data.clone())?;
+    let mut data: &[u8] = &mai.try_borrow_data()?[..];
+    let metadata_obj = Metadata::deserialize(&mut data)?;
     if metadata_obj.mint != mint {
         return Err(LegacyInscriptionErrorCode::BadMint.into());
     }

--- a/programs/libreplex_legacy/src/instructions/set_validation_hash.rs
+++ b/programs/libreplex_legacy/src/instructions/set_validation_hash.rs
@@ -60,8 +60,8 @@ pub fn handler(
     &[ctx.bumps.legacy_inscription]];
 
     let mai = legacy_metadata.to_account_info().clone();
-    let data: &[u8] = &mai.try_borrow_data()?[..];
-    let metadata_obj = Metadata::deserialize(&mut data.clone())?;
+    let mut data: &[u8] = &mai.try_borrow_data()?[..];
+    let metadata_obj = Metadata::deserialize(&mut data)?;
     if metadata_obj.mint != mint.key() {
         return Err(LegacyInscriptionErrorCode::BadMint.into());
     }

--- a/programs/libreplex_legacy/src/instructions/write_to_legacy_inscription_as_uauth.rs
+++ b/programs/libreplex_legacy/src/instructions/write_to_legacy_inscription_as_uauth.rs
@@ -24,6 +24,7 @@ pub struct WriteToLegacyInscriptionAsUAuth<'info> {
     #[account(mut)]
     pub inscription: UncheckedAccount<'info>,
 
+    /// CHECK: Checked via a CPI call
     #[account(mut)]
     pub inscription_v2: UncheckedAccount<'info>,
 

--- a/programs/libreplex_metadata/src/instructions/create_metadata_inscription.rs
+++ b/programs/libreplex_metadata/src/instructions/create_metadata_inscription.rs
@@ -73,6 +73,7 @@ pub struct CreateInscriptionMetadata<'info> {
     #[account(mut)]
     pub inscription: UncheckedAccount<'info>,
 
+    /// CHECK: Checked via CPI
     #[account(mut)]
     pub inscription_v2: UncheckedAccount<'info>,
 


### PR DESCRIPTION
Fix errors from `anchor build`:

```
Struct field "inscription_v2" is unsafe, but is not documented.
        Please add a `/// CHECK:` doc comment explaining why no checks through types are necessary.
        See https://www.anchor-lang.com/docs/the-accounts-struct#safety-checks for more information.
```

Also fix this clippy warning from precommit hook

```
error: call to `.clone()` on a reference in this situation does nothing
  --> programs/libreplex_legacy/src/instructions/set_validation_hash.rs:64:55
   |
64 |     let metadata_obj = Metadata::deserialize(&mut data.clone())?;
   |                                                       ^^^^^^^^ help: remove this redundant call
   |
   = note: the type `[u8]` does not implement `Clone`, so calling `clone` on `&[u8]` copies the reference, which does not do anything and can be removed
   = note: `-D noop-method-call` implied by `-D warnings`
```